### PR TITLE
Some little improvements

### DIFF
--- a/examples/backup-server.lisp
+++ b/examples/backup-server.lisp
@@ -1,0 +1,41 @@
+;; Run two gearman servers using
+;; docker run --rm -p 4730:4730 artefactual/gearmand:1.1.19.1-alpine
+;; docker run --rm -p 4731:4730 artefactual/gearmand:1.1.19.1-alpine
+
+;; 1) Test with two servers
+;; 2) Shutdown the first server and check that still got the answer to the client side
+
+(ql:quickload :cl-gearman)
+
+(defparameter *servers* '("localhost:4730" "localhost:4731"))
+
+;; worker side
+
+(cl-gearman:with-multiple-servers-worker (wx *servers*)
+
+  (defvar lisp-info (lambda (arg job)
+                      (declare (ignorable arg job))
+                      (format nil "~A ~A ~%"
+                              (lisp-implementation-type)
+                              (lisp-implementation-version))))
+
+  (defvar reverse! (lambda (arg job)
+                     (declare (ignorable arg job))
+                     (format nil "~a~%" (reverse arg))))
+
+  (cl-gearman:add-ability wx "task1" lisp-info)
+  (cl-gearman:add-ability wx "task2" reverse!)
+
+  (loop do (handler-bind ((error #'(lambda (c) (invoke-restart 'cl-gearman:skip-job))))
+             (cl-gearman:work wx))))
+
+
+;; client side
+
+(cl-gearman:with-multiple-servers-client (client *servers*)
+  (format t "~A"
+          (cl-gearman:submit-job client "task1"
+                                 :arg ""))
+    (format t "~A"
+          (cl-gearman:submit-job client "task2"
+                                 :arg "Hello Lisp World2!")))

--- a/examples/backup-server.lisp
+++ b/examples/backup-server.lisp
@@ -2,7 +2,7 @@
 ;; docker run --rm -p 4730:4730 artefactual/gearmand:1.1.19.1-alpine
 ;; docker run --rm -p 4731:4730 artefactual/gearmand:1.1.19.1-alpine
 
-;; 1) Test with two servers
+;; 1) Test with two servers active
 ;; 2) Shutdown the first server and check that still got the answer to the client side
 
 (ql:quickload :cl-gearman)
@@ -26,16 +26,19 @@
   (cl-gearman:add-ability wx "task1" lisp-info)
   (cl-gearman:add-ability wx "task2" reverse!)
 
-  (loop do (handler-bind ((error #'(lambda (c) (invoke-restart 'cl-gearman:skip-job))))
-             (cl-gearman:work wx))))
+  (loop
+     do (handler-case (cl-gearman:work wx)
+          (error (c)
+            (format t "Worker lost because of error ~a , please restart this connection ~%" c)))))
 
 
 ;; client side
 
-(cl-gearman:with-multiple-servers-client (client *servers*)
-  (format t "~A"
-          (cl-gearman:submit-job client "task1"
-                                 :arg ""))
+(handler-bind ((error #'(lambda (c) (invoke-restart 'cl-gearman::skip-connection))))
+  (cl-gearman:with-multiple-servers-client (client *servers*)
     (format t "~A"
-          (cl-gearman:submit-job client "task2"
-                                 :arg "Hello Lisp World2!")))
+            (cl-gearman:submit-job client "task1"
+                                   :arg ""))
+    (format t "~A"
+            (cl-gearman:submit-job client "task2"
+                                   :arg "Hello Lisp World!"))))

--- a/src/connection.lisp
+++ b/src/connection.lisp
@@ -35,7 +35,10 @@ MESSAGE and COMMENT offering a :reconnect restart given by RESTART."
                         :comment ,comment)
      (reconnect ()
        :report "Try to reconnect."
-       ,restart)))
+       ,restart)
+     (skip-connection ()
+       :report "Skip connection attempt."
+       nil)))
 
 (defmacro provide-reconnect-restart (expression &body body)
   "When, during the execution of EXPRESSION, an error occurs that can break
@@ -119,3 +122,11 @@ restart."
     (let ((msg (read-message stream)))
       (log-debug (format nil "received response: ~a" msg))
       msg)))
+
+(defmethod is-active ((conn connection))
+  (handler-case (progn
+                  (send-request conn (make-instance 'message :name ECHO_REQ :data (list "test-connection")))
+                  (let ((msg (recv-response conn)))
+                    (message-name? msg ECHO_RES)))
+    (error (err)
+      (log-debug err) nil)))

--- a/src/package.lisp
+++ b/src/package.lisp
@@ -16,6 +16,7 @@
    #:get-job-status
    #:close-client
    #:with-client
+   #:with-multiple-servers-client
 
    ;; worker
    #:worker
@@ -26,6 +27,7 @@
    #:work
    #:close-worker
    #:with-worker
+   #:with-multiple-servers-worker
    #:skip-job
    #:abort-job
    #:retry-job
@@ -40,5 +42,5 @@
    #:log-warn
    #:log-error
    #:log-fatal
-   
+
    ))


### PR DESCRIPTION
- completes select-server method on client & worker
- adds 'skip connection' restart to 'signal-connection-error-with-reconnect-restart' macro
- adds some macro utilities to rise client & workers on multiples gearman servers
- adds one example
- add some code to handle connection errors