### PR TITLE
Fix with-* macros to close server or client connections.

### DIFF
--- a/src/client.lisp
+++ b/src/client.lisp
@@ -111,13 +111,13 @@ automatically discarded"
     (loop for conn in connections do (gm-close conn))))
 
 (defmacro with-client ((var host) &body body)
-  (alexandria:with-gensyms ()
-    `(let ((,var (make-client (list ,host))))
-       ,@body
+  `(let ((,var (make-client (list ,host))))
+     (unwind-protect
+          (progn ,@body)
        (close-client ,var))))
 
 (defmacro with-multiple-servers-client ((var hosts) &body body)
-  (alexandria:with-gensyms ()
-    `(let ((,var (make-client ,hosts)))
-       ,@body
+  `(let ((,var (make-client ,hosts)))
+     (unwind-protect
+          (progn ,@body)
        (close-client ,var))))

--- a/src/connection.lisp
+++ b/src/connection.lisp
@@ -109,9 +109,6 @@ restart."
 (defmethod initialize-instance :after ((conn connection) &key)
   (gm-connect conn))
 
-(defgeneric send-request (conn packet)
-  (:documentation "send request"))
-
 (defun send-request (conn msg)
   (with-slots (stream) conn
     (write-message stream msg))

--- a/src/worker.lisp
+++ b/src/worker.lisp
@@ -112,8 +112,15 @@ automatically discarded"
     (let ((conn (select-server w (make-instance 'job :handle "" :name "" :arg nil)))) ; dummy job
       ;; TODO : retry
       ;;   To support retry, add-ability is needed. with-reconnect-restart is not enough...
-      (let ((job (grab-job conn)))
-        (handle-job-assign w job)))))
+      ;;
+      ;; When previous job was timed out on the server,
+      ;; it will respond ERROR on our ECHO_REQ in `is-active` and
+      ;; `select-server` will might return NIL.
+      ;; That is why we need to run `grab-job` only
+      ;; if connection was found:
+      (when conn
+        (let ((job (grab-job conn)))
+          (handle-job-assign w job))))))
 
 (defmethod close-worker ((w worker))
   (with-slots (connections) w

--- a/src/worker.lisp
+++ b/src/worker.lisp
@@ -120,13 +120,13 @@ automatically discarded"
     (loop for conn in connections do (gm-close conn))))
 
 (defmacro with-worker ((var host) &body body)
-  (alexandria:with-gensyms ()
-    `(let ((,var (make-worker (list ,host))))
-       ,@body
+  `(let ((,var (make-worker (list ,host))))
+     (unwind-protect
+          (progn ,@body)
        (close-worker ,var))))
 
 (defmacro with-multiple-servers-worker ((var hosts) &body body)
-  (alexandria:with-gensyms ()
-    `(let ((,var (make-worker ,hosts)))
-       ,@body
+  `(let ((,var (make-worker ,hosts)))
+     (unwind-protect
+          (progn ,@body)
        (close-worker ,var))))


### PR DESCRIPTION
Body code should be wrapped with `unwind-protect`
to close connect when some code in the body signaled
an error or was interrupted.