### PR TITLE
Fixed error on GEARMAN-CONNECTION-ERROR initialization

### DIFF
--- a/src/connection.lisp
+++ b/src/connection.lisp
@@ -21,7 +21,11 @@
     :initform nil
     :accessor gm-stream)))
 
-(define-condition gearman-connection-error (error) ())
+(define-condition gearman-connection-error (error) 
+  ((message :initarg :message
+            :initform nil)
+   (comment :initarg :comment
+            :initform nil)))
 
 ;;
 ;; macros borrowed from cl-redis

--- a/src/worker.lisp
+++ b/src/worker.lisp
@@ -11,7 +11,7 @@
     :initform nil)
    (abilities
     :initform (make-hash-table :test #'equalp)
-    :accessor :abilities)
+    :accessor abilities)
    (status
     :initform :preparing
     :reader status


### PR DESCRIPTION
Also, I've fixed ABILITIES accessor for WORKER class. It was a keyword and LispWorks issues a warning in such case.