### PR TITLE
Add JOB-FAILED condition and signal it on WORK_FAIL response.

### DIFF
--- a/src/package.lisp
+++ b/src/package.lisp
@@ -28,9 +28,12 @@
    #:close-worker
    #:with-worker
    #:with-multiple-servers-worker
+   #:job-failed
+   #:server-response
    #:skip-job
    #:abort-job
    #:retry-job
+   #:accept-job
 
 
    ;; misc


### PR DESCRIPTION
This change allows to retry job only if the job was failed.

Now client method SUBMIT-JOB signals a special error JOB-FAILED. Previously
it used standard ERROR.

Also, it uses restarts RETRY-JOB and ACCEPT-JOB, used in the worker code as well.
Previously, it used RETRY and ACCEPT names for these retries.